### PR TITLE
Call `Dispose(false)` in `DisposeAsync()`

### DIFF
--- a/src/Components/BaseScopeComponent.cs
+++ b/src/Components/BaseScopeComponent.cs
@@ -77,7 +77,7 @@ public abstract class BaseScopeComponent : OwningComponentBase, IAsyncDisposable
     // See https://github.com/dotnet/aspnetcore/issues/25873#issuecomment-884065550
     => await (ScopedServices as IAsyncDisposable)!.DisposeAsync();
 
-    private IEnumerable<FieldInfo> GetInjectScopeServiceFields()
+  private IEnumerable<FieldInfo> GetInjectScopeServiceFields()
     => GetType()
          .GetFields(BindingFlags.Instance | BindingFlags.NonPublic)
          .Where(field => field.GetCustomAttribute<InjectScopeAttribute>() is not null);

--- a/src/Components/BaseScopeComponent.cs
+++ b/src/Components/BaseScopeComponent.cs
@@ -65,6 +65,7 @@ public abstract class BaseScopeComponent : OwningComponentBase, IAsyncDisposable
   public async ValueTask DisposeAsync()
   {
     await DisposeAsyncCore();
+    Dispose(false);
     GC.SuppressFinalize(this);
   }
 
@@ -76,7 +77,7 @@ public abstract class BaseScopeComponent : OwningComponentBase, IAsyncDisposable
     // See https://github.com/dotnet/aspnetcore/issues/25873#issuecomment-884065550
     => await (ScopedServices as IAsyncDisposable)!.DisposeAsync();
 
-  private IEnumerable<FieldInfo> GetInjectScopeServiceFields()
+    private IEnumerable<FieldInfo> GetInjectScopeServiceFields()
     => GetType()
          .GetFields(BindingFlags.Instance | BindingFlags.NonPublic)
          .Where(field => field.GetCustomAttribute<InjectScopeAttribute>() is not null);

--- a/src/Interop/BaseJsModule.cs
+++ b/src/Interop/BaseJsModule.cs
@@ -11,7 +11,7 @@ public abstract class BaseJsModule : IAsyncDisposable
 
   /// <summary>
   /// Name of this library so that
-  /// derived classes knows where to
+  /// derived classes know where to
   /// load the JS files.
   /// </summary>
   protected string LibraryName =>
@@ -31,8 +31,8 @@ public abstract class BaseJsModule : IAsyncDisposable
   /// <summary>
   /// Some JS functions accept callbacks and since
   /// the implementation of callback for JS interop
-  /// is IDispose, we need to keep track of these
-  /// callback objects so that we dispose them.
+  /// uses IDispose, we need to keep track of these
+  /// callback objects so that we dispose them later.
   /// </summary>
   protected IList<BaseCallbackInterop> CallbackInterops { get; private set; }
 
@@ -40,12 +40,12 @@ public abstract class BaseJsModule : IAsyncDisposable
   /// The Javascript module that contains exported variables,
   /// classes, functions, etc...
   /// <see cref="ImportAsync" /> must be called first before
-  /// this property can be accessed (get).
+  /// this property can be accessed.
   /// </summary>
   /// <exception cref="InvalidOperationException">
   /// Thrown when the module is null (i.e. not loaded yet).
   /// </exception>
-  protected virtual IJSObjectReference Module
+  protected IJSObjectReference Module
   {
     get
     {
@@ -61,7 +61,7 @@ public abstract class BaseJsModule : IAsyncDisposable
 
       return _module;
     }
-    set => _module = value;
+    private set => _module = value;
   }
 
   /// <summary>
@@ -74,7 +74,7 @@ public abstract class BaseJsModule : IAsyncDisposable
   /// <summary>
   /// Indicate the status of the JS module.
   /// </summary>
-  public virtual JsModuleStatus ModuleStatus { get; protected set; }
+  public JsModuleStatus ModuleStatus { get; private set; }
 
   /// <summary>
   /// Constructor.
@@ -95,7 +95,7 @@ public abstract class BaseJsModule : IAsyncDisposable
   /// This only needs to be called once. Calling this method
   /// more than once will do nothing.
   /// </remarks>
-  public virtual async Task ImportAsync()
+  public async Task ImportAsync()
   {
     if (ModuleStatus == JsModuleStatus.Disposed)
     {

--- a/tests/Blazor.Core.TestSample/Modules/DateFormatJsModule.cs
+++ b/tests/Blazor.Core.TestSample/Modules/DateFormatJsModule.cs
@@ -13,7 +13,7 @@ public sealed class DateFormatJsModule : BaseJsModule
   public async Task<string> FormatCurrentDateTimeAsync(Func<DateTime, string> formatter)
   {
     var callbackInterop = new FuncCallbackInterop<DateTime, string>(formatter);
-    _callbackInterops.Add(callbackInterop);
+    CallbackInterops.Add(callbackInterop);
     return await Module.InvokeAsync<string>("formatCurrentDateTime", callbackInterop);
   }
 }

--- a/tests/Blazor.Core.Tests/Components/BaseScopeComponentUnderTest.cs
+++ b/tests/Blazor.Core.Tests/Components/BaseScopeComponentUnderTest.cs
@@ -1,0 +1,65 @@
+using Microsoft.JSInterop;
+
+namespace Blazor.Core.Tests.Components;
+
+public class BaseScopeComponentTests : TestContext
+{
+  // public BaseScopeComponentTests()
+  // {
+  //   Ser
+  // }
+
+  [Fact]
+  public void BaseScopeComponent_InjectScopeServices_ScopeServicesAreDisposed()
+  {
+    // Arrange
+    var scopeServiceDispose = new ScopeServiceDispose();
+    var scopeServiceDisposeAsync = new ScopeServiceDisposeAsync();
+    var scopeServiceDisposeAndDisposeAsync  = new ScopeServiceDisposeAndDisposeAsync();
+    Services.AddScoped(_ => scopeServiceDispose);
+    Services.AddScoped(_ => scopeServiceDisposeAsync);
+    Services.AddScoped(_ => scopeServiceDisposeAndDisposeAsync);
+
+    // Act
+    RenderComponent<BaseScopeComponentUnderTest>();
+    DisposeComponents();
+
+    // Assert
+    Assert.True(scopeServiceDispose.IsDisposed);
+    Assert.True(scopeServiceDispose.IsDisposeCalled);
+    Assert.False(scopeServiceDispose.IsDisposeAsyncCalled);
+    
+    Assert.True(scopeServiceDisposeAsync.IsDisposed);
+    Assert.True(scopeServiceDisposeAsync.IsDisposeAsyncCalled);
+    Assert.False(scopeServiceDisposeAsync.IsDisposeCalled);
+
+    Assert.True(scopeServiceDisposeAndDisposeAsync.IsDisposed);
+    Assert.True(scopeServiceDisposeAndDisposeAsync.IsDisposeAsyncCalled);
+    Assert.False(scopeServiceDisposeAndDisposeAsync.IsDisposeCalled);
+  }
+
+  [Fact]
+  public void BaseScopeComponent_UseAutoImport_JsModuleIsImported()
+  {
+    // Arrange
+    JsModule? jsModule = null;
+    Services.AddScoped(sp =>
+    {
+      var jsRuntime = sp.GetRequiredService<IJSRuntime>();
+      jsModule = new JsModule(jsRuntime);
+      return jsModule;
+    });
+
+    JSInterop.SetupModule("foo.js");
+
+    // Act
+    RenderComponent<BaseScopeComponentWithJsModule>();
+
+    // Assert
+    Assert.NotNull(jsModule);
+    Assert.Equal(JsModuleStatus.Imported, jsModule.ModuleStatus);
+    
+    DisposeComponents();
+    Assert.Equal(JsModuleStatus.Disposed, jsModule.ModuleStatus);
+  }
+}

--- a/tests/Blazor.Core.Tests/Components/BaseScopeComponentUnderTest.cs
+++ b/tests/Blazor.Core.Tests/Components/BaseScopeComponentUnderTest.cs
@@ -4,11 +4,6 @@ namespace Blazor.Core.Tests.Components;
 
 public class BaseScopeComponentTests : TestContext
 {
-  // public BaseScopeComponentTests()
-  // {
-  //   Ser
-  // }
-
   [Fact]
   public void BaseScopeComponent_InjectScopeServices_ScopeServicesAreDisposed()
   {

--- a/tests/Blazor.Core.Tests/Components/ComponentUnderTest.cs
+++ b/tests/Blazor.Core.Tests/Components/ComponentUnderTest.cs
@@ -1,0 +1,33 @@
+using Microsoft.JSInterop;
+
+namespace Blazor.Core.Tests.Components;
+
+public class JsModule : BaseJsModule
+{
+  protected override string ModulePath => "foo.js";
+
+  public JsModule(IJSRuntime jSRuntime) : base(jSRuntime)
+  {}
+}
+
+public class BaseScopeComponentUnderTest : BaseScopeComponent
+{
+#pragma warning disable CS0414 // Remove unused private members  
+  [InjectScope]
+  private readonly ScopeServiceDispose _scopeServiceDispose = null!;
+
+  [InjectScope]
+  private readonly ScopeServiceDisposeAsync _scopeServiceDisposeAsync = null!;
+
+  [InjectScope]
+  private readonly ScopeServiceDisposeAndDisposeAsync _scopeServiceDisposeAndDisposeAsync = null!;
+#pragma warning restore CS0414 // Remove unused private members
+}
+
+public class BaseScopeComponentWithJsModule : BaseScopeComponent
+{
+#pragma warning disable CS0414 // Remove unused private members  
+  [InjectScope, AutoImportJsModule]
+  private readonly JsModule _jsModule = null!;
+#pragma warning restore CS0414 // Remove unused private members
+}

--- a/tests/Blazor.Core.Tests/Components/ComponentUnderTest.cs
+++ b/tests/Blazor.Core.Tests/Components/ComponentUnderTest.cs
@@ -10,9 +10,11 @@ public class JsModule : BaseJsModule
   {}
 }
 
+#pragma warning disable CS0414 // Remove unused private members  
+
 public class BaseScopeComponentUnderTest : BaseScopeComponent
 {
-#pragma warning disable CS0414 // Remove unused private members  
+
   [InjectScope]
   private readonly ScopeServiceDispose _scopeServiceDispose = null!;
 
@@ -21,13 +23,12 @@ public class BaseScopeComponentUnderTest : BaseScopeComponent
 
   [InjectScope]
   private readonly ScopeServiceDisposeAndDisposeAsync _scopeServiceDisposeAndDisposeAsync = null!;
-#pragma warning restore CS0414 // Remove unused private members
 }
 
 public class BaseScopeComponentWithJsModule : BaseScopeComponent
 {
-#pragma warning disable CS0414 // Remove unused private members  
   [InjectScope, AutoImportJsModule]
   private readonly JsModule _jsModule = null!;
-#pragma warning restore CS0414 // Remove unused private members
 }
+
+#pragma warning restore CS0414 // Remove unused private members

--- a/tests/Blazor.Core.Tests/Components/ScopeService.cs
+++ b/tests/Blazor.Core.Tests/Components/ScopeService.cs
@@ -1,0 +1,47 @@
+namespace Blazor.Core.Tests.Components;
+
+public abstract class ScopeService
+{
+  public bool IsDisposed { get; protected set; } = false;
+
+  public bool IsDisposeCalled { get; protected set; } = false;
+
+  public bool IsDisposeAsyncCalled { get; protected set; } = false;
+}
+
+public class ScopeServiceDispose : ScopeService, IDisposable
+{
+  public void Dispose()
+  {
+    Dispose(true);
+    IsDisposeCalled = true;
+    GC.SuppressFinalize(this);
+  }
+
+  protected virtual void Dispose(bool disposing)
+  {
+    IsDisposed = true;
+  }
+}
+
+public class ScopeServiceDisposeAsync : ScopeService, IAsyncDisposable
+{
+  public ValueTask DisposeAsync()
+  {
+    IsDisposeAsyncCalled = true;
+    IsDisposed = true;
+    GC.SuppressFinalize(this);
+    return ValueTask.CompletedTask;
+  }
+}
+
+public class ScopeServiceDisposeAndDisposeAsync : ScopeServiceDispose, IAsyncDisposable
+{
+  public ValueTask DisposeAsync()
+  {
+    IsDisposeAsyncCalled = true;
+    Dispose(false);
+    GC.SuppressFinalize(this);
+    return ValueTask.CompletedTask;
+  }
+}

--- a/tests/Blazor.Core.Tests/IndexPageTests.cs
+++ b/tests/Blazor.Core.Tests/IndexPageTests.cs
@@ -8,10 +8,10 @@ public class IndexPageTests
 
   private readonly PlaywrightFixture _playwrightFixture = null!;
 
-  public IndexPageTests(PlaywrightFixture playwrightFixture)
-  {
-    _playwrightFixture = playwrightFixture;
-  }
+  // public IndexPageTests(PlaywrightFixture playwrightFixture)
+  // {
+  //   _playwrightFixture = playwrightFixture;
+  // }
 
   [InlineData(1)]
   [InlineData(5)]

--- a/tests/Blazor.Core.Tests/Usings.cs
+++ b/tests/Blazor.Core.Tests/Usings.cs
@@ -2,6 +2,7 @@ global using Xunit;
 global using Microsoft.Playwright;
 global using FluentAssertions;
 
+global using Blazor.Core.Components;
 global using Blazor.Core.TestSample;
 global using Blazor.Core.Tests.Fixtures;
 global using Blazor.Core.Interop;


### PR DESCRIPTION
* Additionally make protected fields into protected properties
* Make virtual members into non-virtual because we don't want derive class to change this behaviour