### PR TITLE
Improve `StringEnum`

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,3 +185,65 @@ add the module class to your DI container, and use the module like this:
   }
 }
 ```
+
+# String Enum
+This library also includes a class named `StringEnum`. Purpose of this class is to
+represent discrete values as string, like `enum` but uses `string`.
+
+To define your custom string enum, inherit `StringEnum` like the example below.
+```cs
+public sealed class Color : StringEnum
+{
+  // Make this private so that no one else can create Color object
+  private Color(string value) : base(value) {}
+
+  public readonly static Color Blue = new("blue");
+
+  public readonly static Color Green = new("green");
+
+  public readonly static Color Red = new("red");
+}
+
+// Usage
+Color blue = Color.Blue;
+string blueStr = blue; // Implicit cast to string - blueStr is now "blue"
+```
+
+Defining multiple enums with the same value is not allowed. Doing so will cause
+an exception during runtime.
+```cs
+public sealed class Color : StringEnum
+{
+  private Color(string value) : base(value) {}
+
+  public readonly static Color Blue = new("blue");
+
+  public readonly static Color Green = new("blue"); // ❌ Cannot have two "blue" in a string enum
+}
+```
+
+## Converters
+To make it easy to work with JSOn serialization, this library includes this converter
+`StringEnumConverter<T>`. This converter enables serializing a `StringEnum` to a literal string value.
+
+Note this is a converter for `System.Text.Json`.
+
+```cs
+using System.Text.Json.Serialization;
+
+[JsonConverter(typeof(StringEnumConverter<Color>))]
+public sealed class Color : StringEnum
+{
+  private Color(string value) : base(value) {}
+
+  public readonly static Color Blue = new("blue");
+
+  public readonly static Color Green = new("green");
+
+  public readonly static Color Red = new("red");
+}
+
+var json = JsonSerializer.Serialize(Color.Red);
+// With the converter, json is "\"red\""
+// Without the converter, json is "{\"Value\":\"red\"}"
+```

--- a/src/Enums/StringEnum.cs
+++ b/src/Enums/StringEnum.cs
@@ -114,7 +114,7 @@ public abstract class StringEnum
       return (TStringEnum)StringEnumValuesMapping[type][value];
     }
 
-    throw new ArgumentException($"Value \"{value}\" not found.");
+    throw new ArgumentException($"Value \"{value}\" not found in string enum \"{type.FullName}\".");
   }
 
   /// <summary>

--- a/src/Enums/StringEnumConverter.cs
+++ b/src/Enums/StringEnumConverter.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Blazor.Core.Enums;
+
+/// <summary>
+/// This converter converts an <see cref="StringEnum"/> object
+/// to a literal string object.
+/// Borrowed idea from https://watzek.dev/posts/2023/09/16/solving-the-dictionary-json-serialization-puzzle-in-.net/.
+/// </summary>
+/// <typeparam name="TEnum">String enum type.</typeparam>
+public class StringEnumConverter<TEnum> : JsonConverter<TEnum?> where TEnum : StringEnum
+{
+  /// <inheritdoc />
+  public override TEnum? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+  {
+    try
+    {
+      var value = reader.GetString();
+      return (value is null) ? null : StringEnum.Get<TEnum>(value);
+    }
+    catch (ArgumentException ex)
+    {
+      throw new JsonException($"Failed to parse JSON to \"{typeToConvert.FullName}\" " +
+                              "because value doesn't exist.", ex);
+    }
+  }
+
+  /// <inheritdoc />
+  public override void Write(Utf8JsonWriter writer, TEnum? value, JsonSerializerOptions options)
+  {
+    if (value is null)
+    {
+      writer.WriteNullValue();
+      return;
+    }
+
+    writer.WriteStringValue(value.Value);
+  }
+
+  /// <inheritdoc />
+  public override void WriteAsPropertyName(Utf8JsonWriter writer, TEnum? value, JsonSerializerOptions options)
+  {
+    if (value is null)
+    {
+      return;
+    }
+
+    writer.WritePropertyName(value.Value);
+  }
+
+  /// <inheritdoc />
+  public override TEnum? ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    => Read(ref reader, typeToConvert, options);
+}

--- a/tests/Blazor.Core.Tests/Converters/JsonConverterExtensions.cs
+++ b/tests/Blazor.Core.Tests/Converters/JsonConverterExtensions.cs
@@ -1,0 +1,72 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Blazor.Core.Tests.Converters;
+
+/// <summary>
+/// Taken from: https://khalidabuhakmeh.com/systemtextjson-jsonconverter-test-helpers
+/// </summary>
+public static class JsonConverterTestExtensions
+{
+  public static TResult? Read<TResult>(
+    this JsonConverter<TResult> converter, 
+    string token,
+    JsonSerializerOptions? options = null)
+  {
+    options ??= JsonSerializerOptions.Default;
+    var bytes = Encoding.UTF8.GetBytes(token);
+    var reader = new Utf8JsonReader(bytes);
+    
+    // Advance to token
+    reader.Read();
+    return converter.Read(ref reader, typeof(TResult), options);
+  }
+
+  public static string Write<T>(
+    this JsonConverter<T> converter, 
+    T value,
+    JsonSerializerOptions? options = null)
+  {
+    options ??= JsonSerializerOptions.Default;
+    using var memoryStream = new MemoryStream();
+    using var writer = new Utf8JsonWriter(memoryStream);
+
+    converter.Write(writer, value, options);
+    writer.Flush();
+    return Encoding.UTF8.GetString(memoryStream.ToArray());
+  }
+
+  public static TResult? ReadAsPropertyName<TResult>(
+    this JsonConverter<TResult> converter, 
+    string token,
+    JsonSerializerOptions? options = null)
+  {
+    options ??= JsonSerializerOptions.Default;
+    var bytes = Encoding.UTF8.GetBytes(token);
+    var reader = new Utf8JsonReader(bytes);
+    
+    // Advance to token
+    reader.Read();
+    return converter.ReadAsPropertyName(ref reader, typeof(TResult), options);
+  }
+
+  public static string WriteAsPropertyName<T>(
+    this JsonConverter<T> converter, 
+    T key,
+    string value,
+    JsonSerializerOptions? options = null)
+  {
+    options ??= JsonSerializerOptions.Default;
+    using var memoryStream = new MemoryStream();
+    using var writer = new Utf8JsonWriter(memoryStream);
+
+    writer.WriteStartObject();
+    converter.WriteAsPropertyName(writer, key, options);
+    writer.WriteStringValue(value);
+    writer.WriteEndObject();
+
+    writer.Flush();
+    return Encoding.UTF8.GetString(memoryStream.ToArray());
+  }
+}

--- a/tests/Blazor.Core.Tests/Enums/StringEnumConverterTests.cs
+++ b/tests/Blazor.Core.Tests/Enums/StringEnumConverterTests.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+using Blazor.Core.Enums;
+using Blazor.Core.Tests.Converters;
+
+namespace Blazor.Core.Tests.Enums;
+
+public class StringEnumConverterTests
+{
+  private readonly StringEnumConverter<Color> _stringEnumConverter;
+
+  public StringEnumConverterTests()
+  {
+    _stringEnumConverter = new();
+  }
+
+  [Fact]
+  public void Write_SerializeStringEnum_ReturnsStringLiteral()
+  {
+    // Act
+    var jsonStr = _stringEnumConverter.Write(Color.Red);
+
+    // Assert
+    Assert.Equal($"\"{Color.Red}\"", jsonStr);
+  }
+
+  [Fact]
+  public void Write_SerializeNullStringEnum_ReturnsNullLiteral()
+  {
+    // Act
+    var jsonStr = _stringEnumConverter.Write(null);
+
+    // Assert
+    Assert.Equal("null", jsonStr);
+  }
+
+  [Fact]
+  public void WritePropertyName_SerializeStringEnumAsKey_ReturnsStringEnumValueAsKey()
+  {
+    // Act
+    var jsonStr = _stringEnumConverter.WriteAsPropertyName(Color.Red, "red-value");
+
+    // Assert
+    Assert.Equal("{\"red\":\"red-value\"}", jsonStr);
+  }
+
+  [Fact]
+  public void Read_ValidStringEnumValue_DeserializesCorrectly()
+  {
+    // Act
+    var redColor = _stringEnumConverter.Read("\"red\"");
+
+    // Assert
+    Assert.Equal(Color.Red, redColor);
+  }
+
+  [Fact]
+  public void Read_InvalidStringEnumValue_ThrowsException()
+  {
+    Assert.Throws<JsonException>(() => _stringEnumConverter.Read("\"cyan\""));
+  }
+
+  [Fact]
+  public void ReadAsPropertyName_ValidStringEnumValue_DeserializesCorrectly()
+  {
+    // Act
+    var redColor = _stringEnumConverter.ReadAsPropertyName("\"red\"");
+
+    // Assert
+    Assert.Equal(Color.Red, redColor);
+  }
+
+  [Fact]
+  public void ReadAsPropertyName_InvalidStringEnumValue_ThrowsException()
+  {
+    Assert.Throws<JsonException>(() => _stringEnumConverter.ReadAsPropertyName("\"cyan\""));
+  }
+}

--- a/tests/Blazor.Core.Tests/Enums/StringEnumTests.cs
+++ b/tests/Blazor.Core.Tests/Enums/StringEnumTests.cs
@@ -2,35 +2,6 @@ using Blazor.Core.Enums;
 
 namespace Blazor.Core.Tests.Enums;
 
-public class Color : StringEnum
-{
-  private Color(string value) : base(value) {}
-
-  public readonly static Color Blue = new("blue");
-
-  public readonly static Color Green = new("green");
-
-  public readonly static Color Red = new("red");
-}
-
-public class ComputerColor : StringEnum
-{
-  private ComputerColor(string value) : base(value) {}
-
-  public static readonly ComputerColor Red = new("red");
-}
-
-public class Operation : StringEnum
-{
-  private Operation(string value) : base(value) {}
-
-  public readonly static Operation Read = new("read");
-
-  public readonly static Operation DuplicateRead = new("read");
-
-  public readonly static Operation Write = new("write");
-}
-
 public class StringEnumTests
 {
   [Fact]

--- a/tests/Blazor.Core.Tests/Enums/StringEnumTests.cs
+++ b/tests/Blazor.Core.Tests/Enums/StringEnumTests.cs
@@ -4,11 +4,9 @@ namespace Blazor.Core.Tests.Enums;
 
 public class Color : StringEnum
 {
-  protected Color(string value) : base(value) {}
+  private Color(string value) : base(value) {}
 
   public readonly static Color Blue = new("blue");
-
-  // public readonly static Color Purple = new("blue");
 
   public readonly static Color Green = new("green");
 
@@ -24,7 +22,7 @@ public class ComputerColor : StringEnum
 
 public class Operation : StringEnum
 {
-  protected Operation(string value) : base(value) {}
+  private Operation(string value) : base(value) {}
 
   public readonly static Operation Read = new("read");
 
@@ -35,6 +33,12 @@ public class Operation : StringEnum
 
 public class StringEnumTests
 {
+  [Fact]
+  public void AccessStringEnum_HasDuplicateValues_ThrowsException()
+  {
+    Assert.Throws<TypeInitializationException>(() => Operation.Write);
+  }
+
   [InlineData("red")]
   [InlineData("blue")]
   [InlineData("green")]
@@ -53,7 +57,7 @@ public class StringEnumTests
   [Fact]
   public void Contains_DoesNotContainValueFromAnotherStringEnum_ReturnsFalse()
   {
-    Assert.False(StringEnum.Contains<ComputerColor>("blue"));
+    Assert.False(StringEnum.Contains<ComputerColor>(Color.Blue));
   }
 
   [Fact]

--- a/tests/Blazor.Core.Tests/Enums/TestEnums.cs
+++ b/tests/Blazor.Core.Tests/Enums/TestEnums.cs
@@ -1,0 +1,32 @@
+using Blazor.Core.Enums;
+
+namespace Blazor.Core.Tests.Enums;
+
+public class Color : StringEnum
+{
+  private Color(string value) : base(value) {}
+
+  public readonly static Color Blue = new("blue");
+
+  public readonly static Color Green = new("green");
+
+  public readonly static Color Red = new("red");
+}
+
+public class ComputerColor : StringEnum
+{
+  private ComputerColor(string value) : base(value) {}
+
+  public static readonly ComputerColor Red = new("red");
+}
+
+public class Operation : StringEnum
+{
+  private Operation(string value) : base(value) {}
+
+  public readonly static Operation Read = new("read");
+
+  public readonly static Operation DuplicateRead = new("read");
+
+  public readonly static Operation Write = new("write");
+}


### PR DESCRIPTION
* Throw exception when accessing a string enum whose definition has duplicate values
* Add `StringEnumConverter`